### PR TITLE
Add hooks for providing alternative items, subjects, and thumbnail images

### DIFF
--- a/Example/Tests/XExtensionItemParametersTests.m
+++ b/Example/Tests/XExtensionItemParametersTests.m
@@ -17,6 +17,10 @@
 
 @implementation XExtensionItemParametersTests
 
+- (void)testItemSourceThrowsIfPlaceholderIsNil {
+    XCTAssertThrows([[XExtensionItemSource alloc] initWithPlaceholderItem:nil attachments:nil]);
+}
+
 - (void)testAttributedTitle {
     XExtensionItemSource *itemSource = [[XExtensionItemSource alloc] initWithPlaceholderItem:@"" attachments:@[]];
     itemSource.attributedTitle = [[NSAttributedString alloc] initWithString:@"Foo" attributes:@{ NSFontAttributeName: [UIFont boldSystemFontOfSize:20] }];
@@ -164,6 +168,22 @@
     XCTAssertNoThrow([xExtensionItem.referrer.androidAppURL absoluteString]);
 }
 
+- (void)testRegisteringItemProvidingBlockThrowsIfBlockIsNil {
+    XExtensionItemSource *itemSource = [[XExtensionItemSource alloc] initWithPlaceholderItem:@"" attachments:@[]];
+    
+    XCTAssertThrows([itemSource registerItemProvidingBlock:nil forActivityType:UIActivityTypeMail]);
+}
+
+- (void)testRegisteringItemProvidingBlockThrowsIfActivityTypeIsNil {
+    XExtensionItemSource *itemSource = [[XExtensionItemSource alloc] initWithPlaceholderItem:@"" attachments:@[]];
+    
+    XExtensionItemThumbnailProvidingBlock block = ^UIImage *(CGSize suggestedSize) {
+        return nil;
+    };
+    
+    XCTAssertThrows([itemSource registerItemProvidingBlock:block forActivityType:nil]);
+}
+
 - (void)testRegisteringItemProvidingBlockReturnsRegisteredItemForTwitterActivity {
     NSString *twitterString = @"Foo";
     
@@ -210,7 +230,19 @@
     XCTAssertNil([itemSource activityViewController:nil subjectForActivityType:UIActivityTypeMessage]);
 }
 
-- (void)testRegisteringThumbnailProdivingBlockReturnsThumbnailForTwitterActivity {
+- (void)testRegisteringSubjectThrowsIfSubjectIsNil {
+    XExtensionItemSource *itemSource = [[XExtensionItemSource alloc] initWithPlaceholderItem:@"" attachments:@[]];
+    
+    XCTAssertThrows([itemSource registerSubject:nil forActivityType:UIActivityTypeMail]);
+}
+
+- (void)testRegisteringSubjectThrowsIfActivityTypeIsNil {
+    XExtensionItemSource *itemSource = [[XExtensionItemSource alloc] initWithPlaceholderItem:@"" attachments:@[]];
+    
+    XCTAssertThrows([itemSource registerSubject:@"" forActivityType:nil]);
+}
+
+- (void)testRegisteringThumbnailProvidingBlockReturnsThumbnailForTwitterActivity {
     UIImage *image = [[UIImage alloc] initWithData:[@"" dataUsingEncoding:NSUTF8StringEncoding]];
     
     XExtensionItemSource *itemSource = [[XExtensionItemSource alloc] initWithPlaceholderItem:@"Bar" attachments:@[]];
@@ -222,7 +254,7 @@
     XCTAssertEqualObjects(image, [itemSource activityViewController:nil thumbnailImageForActivityType:UIActivityTypePostToTwitter suggestedSize:CGSizeZero]);
 }
 
-- (void)testRegisteringThumbnailProdivingBlockReturnsNilForNonTwitterActivity {
+- (void)testRegisteringThumbnailProvidingBlockReturnsNilForNonTwitterActivity {
     UIImage *image = [[UIImage alloc] initWithData:[@"" dataUsingEncoding:NSUTF8StringEncoding]];
     
     XExtensionItemSource *itemSource = [[XExtensionItemSource alloc] initWithPlaceholderItem:@"Bar" attachments:@[]];
@@ -232,6 +264,22 @@
     } forActivityType:UIActivityTypePostToTwitter];
     
     XCTAssertNil([itemSource activityViewController:nil thumbnailImageForActivityType:UIActivityTypeMail suggestedSize:CGSizeZero]);
+}
+
+- (void)testRegisteringThumbnailProvidingBlockThrowsIfBlockIsNil {
+    XExtensionItemSource *itemSource = [[XExtensionItemSource alloc] initWithPlaceholderItem:@"" attachments:@[]];
+    
+    XCTAssertThrows([itemSource registerThumbnailProvidingBlock:nil forActivityType:UIActivityTypeMail]);
+}
+
+- (void)testRegisteringThumbnailProvidingBlockThrowsIfActivityTypeIsNil {
+    XExtensionItemSource *itemSource = [[XExtensionItemSource alloc] initWithPlaceholderItem:@"" attachments:@[]];
+    
+    XExtensionItemThumbnailProvidingBlock block = ^UIImage *(CGSize suggestedSize) {
+        return nil;
+    };
+    
+    XCTAssertThrows([itemSource registerThumbnailProvidingBlock:block forActivityType:nil]);
 }
 
 @end

--- a/Example/Tests/XExtensionItemParametersTests.m
+++ b/Example/Tests/XExtensionItemParametersTests.m
@@ -10,7 +10,7 @@
 @implementation XExtensionItemParametersTests
 
 - (void)testAttributedTitle {
-    XExtensionItemSource *itemSource = [[XExtensionItemSource alloc] init];
+    XExtensionItemSource *itemSource = [[XExtensionItemSource alloc] initWithPlaceholderItem:@"" attachments:@[]];
     itemSource.attributedTitle = [[NSAttributedString alloc] initWithString:@"Foo" attributes:@{ NSFontAttributeName: [UIFont boldSystemFontOfSize:20] }];
     
     XExtensionItem *xExtensionItem = [[XExtensionItem alloc] initWithExtensionItem:[itemSource activityViewController:nil itemForActivityType:nil]];
@@ -19,7 +19,7 @@
 }
 
 - (void)testAttributedContentText {
-    XExtensionItemSource *itemSource = [[XExtensionItemSource alloc] init];
+    XExtensionItemSource *itemSource = [[XExtensionItemSource alloc] initWithPlaceholderItem:@"" attachments:@[]];
     itemSource.attributedContentText = [[NSAttributedString alloc] initWithString:@"Foo" attributes:@{ NSFontAttributeName: [UIFont boldSystemFontOfSize:20] }];
     
     XExtensionItem *xExtensionItem = [[XExtensionItem alloc] initWithExtensionItem:[itemSource activityViewController:nil itemForActivityType:nil]];
@@ -44,7 +44,7 @@
 }
 
 - (void)testTags {
-    XExtensionItemSource *itemSource = [[XExtensionItemSource alloc] init];
+    XExtensionItemSource *itemSource = [[XExtensionItemSource alloc] initWithPlaceholderItem:@"" attachments:@[]];
     itemSource.tags = @[@"foo", @"bar", @"baz"];
     
     XExtensionItem *xExtensionItem = [[XExtensionItem alloc] initWithExtensionItem:[itemSource activityViewController:nil itemForActivityType:nil]];
@@ -53,7 +53,7 @@
 }
 
 - (void)testSourceURL {
-    XExtensionItemSource *itemSource = [[XExtensionItemSource alloc] init];
+    XExtensionItemSource *itemSource = [[XExtensionItemSource alloc] initWithPlaceholderItem:@"" attachments:@[]];
     itemSource.sourceURL = [NSURL URLWithString:@"http://tumblr.com"];
     
     XExtensionItem *xExtensionItem = [[XExtensionItem alloc] initWithExtensionItem:[itemSource activityViewController:nil itemForActivityType:nil]];
@@ -62,7 +62,7 @@
 }
 
 - (void)testReferrer {
-    XExtensionItemSource *itemSource = [[XExtensionItemSource alloc] init];
+    XExtensionItemSource *itemSource = [[XExtensionItemSource alloc] initWithPlaceholderItem:@"" attachments:@[]];
     itemSource.referrer = [[XExtensionItemReferrer alloc] initWithAppName:@"Tumblr"
                                                                appStoreID:@"12345"
                                                              googlePlayID:@"54321"
@@ -76,7 +76,7 @@
 }
 
 - (void)testReferrerFromBundle {
-    XExtensionItemSource *itemSource = [[XExtensionItemSource alloc] init];
+    XExtensionItemSource *itemSource = [[XExtensionItemSource alloc] initWithPlaceholderItem:@"" attachments:@[]];
     itemSource.referrer = [[XExtensionItemReferrer alloc] initWithAppNameFromBundle:[NSBundle bundleForClass:[self class]]
                                                                          appStoreID:@"12345"
                                                                        googlePlayID:@"54321"
@@ -90,7 +90,7 @@
 }
 
 - (void)testUserInfo {
-    XExtensionItemSource *itemSource = [[XExtensionItemSource alloc] init];
+    XExtensionItemSource *itemSource = [[XExtensionItemSource alloc] initWithPlaceholderItem:@"" attachments:@[]];
     itemSource.sourceURL = [NSURL URLWithString:@"http://tumblr.com"];
     itemSource.userInfo = @{ @"foo": @"bar" };
     
@@ -107,7 +107,7 @@
     CustomParameters *inputCustomParameters = [[CustomParameters alloc] init];
     inputCustomParameters.customParameter = @"Value";
     
-    XExtensionItemSource *itemSource = [[XExtensionItemSource alloc] init];
+    XExtensionItemSource *itemSource = [[XExtensionItemSource alloc] initWithPlaceholderItem:@"" attachments:@[]];
     [itemSource addEntriesToUserInfo:inputCustomParameters];
     
     XExtensionItem *xExtensionItem = [[XExtensionItem alloc] initWithExtensionItem:[itemSource activityViewController:nil itemForActivityType:nil]];

--- a/Pod/Classes/XExtensionItem.h
+++ b/Pod/Classes/XExtensionItem.h
@@ -2,6 +2,22 @@
 #import "XExtensionItemDictionarySerializing.h"
 
 /**
+ *  <#Description#>
+ *
+ *  @return <#return value description#>
+ */
+typedef id (^XExtensionItemProvider)();
+
+/**
+ *  <#Description#>
+ *
+ *  @param suggestedSize <#suggestedSize description#>
+ *
+ *  @return <#return value description#>
+ */
+typedef UIImage *(^XExtensionItemThumbnailProvider)(CGSize suggestedSize);
+
+/**
  A data structure that application developers can use to pass well-defined data structures into iOS 8 extensions 
  (extension developers can then use the `XExtensionItem` class to read this data).
  
@@ -108,7 +124,38 @@
  */
 - (void)addEntriesToUserInfo:(id <XExtensionItemDictionarySerializing>)dictionarySerializable;
 
-// TODO: Add methods for providing overrides for system activities (e.g. Facebook)
+/**
+ *  Register an item to be provided if a specific activity is selected e.g. `UIActivityTypePostToFacebook`. 
+ *  
+ *  @discussion By default, this class provides an `NSExtensionItem` that includes all of the attachments passed to this 
+ *  instance’s initializer, plus any of this class’s other properties which have been populated. This method should be 
+ *  used if you’d like to provide an alternative item on a per-activity basis. 
+ *  
+ *  A good example usage would be to provide a special HTML string in the event that `UIActivityTypeMail` is selected.
+ *
+ *  @param itemProvider (Required) A block that will be called if the activity with the specified type is selected. It 
+ *  should return the item to be provided to this activity.
+ *  @param activityType (Required) The activity type that the subject should be provided to.
+ */
+- (void)registerItemProvider:(XExtensionItemProvider)itemProvider forActivityType:(NSString *)activityType;
+
+/**
+ *  Registers a subject for activities that support separate subject and data fields.
+ *
+ *  @param subject      (Required) A string to use as the contents of the subject field.
+ *  @param activityType (Required) The activity type that the subject should be provided to.
+ */
+- (void)registerSubject:(NSString *)subject forActivityType:(NSString *)activityType;
+
+/**
+ *  Registers a thumbnail preview image for activities that support a preview image.
+ *
+ *  @param thumbnailProvider (Required) A block that will be called with the suggested size for the thumbnail image, in 
+ *  points. It should return an image using the appropriate scale for the screen. Images provided at the suggested size 
+ *  will result in the best experience.
+ *  @param activityType      (Required) The activity type that the subject should be provided to.
+ */
+- (void)registerThumbnailProvider:(XExtensionItemThumbnailProvider)thumbnailProvider forActivityType:(NSString *)activityType;
 
 @end
 
@@ -118,7 +165,8 @@
  A data structure that iOS 8 extension developers can use to retrieve well-defined data structures from applications 
  (application developers will have provided this data using the `XExtensionItemSource` class).
  
- Convert incoming `NSExtensionItem` instances retrieved from an extension context into `XExtensionItem` instances:
+ @discussion Convert incoming `NSExtensionItem` instances retrieved from an extension context into `XExtensionItem` 
+ instances:
  
  ```objc
  for (NSExtensionItem *inputItem in self.extensionContext.inputItems) {

--- a/Pod/Classes/XExtensionItem.h
+++ b/Pod/Classes/XExtensionItem.h
@@ -6,7 +6,7 @@
  *
  *  @return <#return value description#>
  */
-typedef id (^XExtensionItemProvider)();
+typedef id (^XExtensionItemProvidingBlock)();
 
 /**
  *  <#Description#>
@@ -15,7 +15,7 @@ typedef id (^XExtensionItemProvider)();
  *
  *  @return <#return value description#>
  */
-typedef UIImage *(^XExtensionItemThumbnailProvider)(CGSize suggestedSize);
+typedef UIImage *(^XExtensionItemThumbnailProvidingBlock)(CGSize suggestedSize);
 
 /**
  A data structure that application developers can use to pass well-defined data structures into iOS 8 extensions 
@@ -133,11 +133,11 @@ typedef UIImage *(^XExtensionItemThumbnailProvider)(CGSize suggestedSize);
  *  
  *  A good example usage would be to provide a special HTML string in the event that `UIActivityTypeMail` is selected.
  *
- *  @param itemProvider (Required) A block that will be called if the activity with the specified type is selected. It 
+ *  @param itemBlock    (Required) A block that will be called if the activity with the specified type is selected. It
  *  should return the item to be provided to this activity.
  *  @param activityType (Required) The activity type that the subject should be provided to.
  */
-- (void)registerItemProvider:(XExtensionItemProvider)itemProvider forActivityType:(NSString *)activityType;
+- (void)registerItemProvidingBlock:(XExtensionItemProvidingBlock)itemBlock forActivityType:(NSString *)activityType;
 
 /**
  *  Registers a subject for activities that support separate subject and data fields.
@@ -150,12 +150,12 @@ typedef UIImage *(^XExtensionItemThumbnailProvider)(CGSize suggestedSize);
 /**
  *  Registers a thumbnail preview image for activities that support a preview image.
  *
- *  @param thumbnailProvider (Required) A block that will be called with the suggested size for the thumbnail image, in 
+ *  @param thumbnailBlock    (Required) A block that will be called with the suggested size for the thumbnail image, in
  *  points. It should return an image using the appropriate scale for the screen. Images provided at the suggested size 
  *  will result in the best experience.
  *  @param activityType      (Required) The activity type that the subject should be provided to.
  */
-- (void)registerThumbnailProvider:(XExtensionItemThumbnailProvider)thumbnailProvider forActivityType:(NSString *)activityType;
+- (void)registerThumbnailProvidingBlock:(XExtensionItemThumbnailProvidingBlock)thumbnailBlock forActivityType:(NSString *)activityType;
 
 @end
 

--- a/Pod/Classes/XExtensionItem.m
+++ b/Pod/Classes/XExtensionItem.m
@@ -23,7 +23,6 @@ static NSString * const ParameterKeyTags = @"tags";
 
 - (instancetype)initWithPlaceholderItem:(id)placeholderItem attachments:(NSArray *)attachments {
     NSParameterAssert(placeholderItem);
-    NSParameterAssert(attachments);
     
     self = [super init];
     if (self) {

--- a/Pod/Classes/XExtensionItem.m
+++ b/Pod/Classes/XExtensionItem.m
@@ -52,12 +52,12 @@ static NSString * const ParameterKeyTags = @"tags";
     });
 }
 
-- (void)registerItemProvider:(XExtensionItemProvider)itemProvider forActivityType:(NSString *)activityType {
-    NSParameterAssert(itemProvider);
+- (void)registerItemProvidingBlock:(XExtensionItemProvidingBlock)itemBlock forActivityType:(NSString *)activityType {
+    NSParameterAssert(itemBlock);
     NSParameterAssert(activityType);
     
-    if (activityType && itemProvider) {
-        self.activityTypesToItemProviderBlocks[activityType] = itemProvider;
+    if (activityType && itemBlock) {
+        self.activityTypesToItemProviderBlocks[activityType] = itemBlock;
     }
 }
 
@@ -70,12 +70,12 @@ static NSString * const ParameterKeyTags = @"tags";
     }
 }
 
-- (void)registerThumbnailProvider:(XExtensionItemThumbnailProvider)thumbnailProvider forActivityType:(NSString *)activityType {
-    NSParameterAssert(thumbnailProvider);
+- (void)registerThumbnailProvidingBlock:(XExtensionItemThumbnailProvidingBlock)thumbnailBlock forActivityType:(NSString *)activityType {
+    NSParameterAssert(thumbnailBlock);
     NSParameterAssert(activityType);
     
-    if (activityType && thumbnailProvider) {
-        self.activityTypesToThumbnailProviderBlocks[activityType] = thumbnailProvider;
+    if (activityType && thumbnailBlock) {
+        self.activityTypesToThumbnailProviderBlocks[activityType] = thumbnailBlock;
     }
 }
 
@@ -93,10 +93,10 @@ static NSString * const ParameterKeyTags = @"tags";
 - (UIImage *)activityViewController:(UIActivityViewController *)activityViewController
       thumbnailImageForActivityType:(NSString *)activityType
                       suggestedSize:(CGSize)size {
-    XExtensionItemThumbnailProvider provider = self.activityTypesToThumbnailProviderBlocks[activityType];
+    XExtensionItemThumbnailProvidingBlock thumbnailBlock = self.activityTypesToThumbnailProviderBlocks[activityType];
     
-    if (provider) {
-        return provider(size);
+    if (thumbnailBlock) {
+        return thumbnailBlock(size);
     }
     else {
         return nil;
@@ -105,10 +105,10 @@ static NSString * const ParameterKeyTags = @"tags";
 
 - (id)activityViewController:(UIActivityViewController *)activityViewController
          itemForActivityType:(NSString *)activityType {
-    XExtensionItemProvider itemProvider = self.activityTypesToItemProviderBlocks[activityType];
+    XExtensionItemProvidingBlock itemBlock = self.activityTypesToItemProviderBlocks[activityType];
     
-    if (itemProvider) {
-        return itemProvider();
+    if (itemBlock) {
+        return itemBlock();
     }
     else {
         return self.extensionItemRepresentation;


### PR DESCRIPTION
Adds hooks for providing alternative items, subjects, and thumbnail images on a per-activity type basis. Addresses the following tickets:

* https://github.com/tumblr/XExtensionItem/issues/33
* https://github.com/tumblr/XExtensionItem/issues/35

I’m going to punt on updating the README for now since I want to do a [bigger pass at rewriting it for 1.0](https://github.com/tumblr/XExtensionItem/issues/32).

Other requests which have been broken out into separate issues:

* https://github.com/tumblr/XExtensionItem/issues/40
* https://github.com/tumblr/XExtensionItem/issues/41