### PR TITLE
Add Weibo to the whitelist of system activities that can take extension items as input

### DIFF
--- a/Pod/Classes/XExtensionItem.m
+++ b/Pod/Classes/XExtensionItem.m
@@ -186,38 +186,24 @@ static BOOL isExtensionItemInputAcceptedByActivityType(NSString *activityType) {
                                                              UIActivityTypeSaveToCameraRoll,
                                                              UIActivityTypeAddToReadingList,
                                                              UIActivityTypeAirDrop,
-                                                             
-                                                             /*
-                                                              I’m guessing that these accept `NSExtensionItem` input but 
-                                                              have not yet been able to verify.
-                                                              */
-                                                             UIActivityTypePostToWeibo,
-                                                             UIActivityTypePostToTencentWeibo
                                                              ]];
     
+    /*
+     The following activities are capable of taking `NSExtensionItem` instances as input. They display system share 
+     sheets that consume the extension item’s `attributedContentText` value.
+     */
     NSSet *acceptingTypes = [[NSSet alloc] initWithArray:@[
+                                                           UIActivityTypePostToTwitter,
+                                                           UIActivityTypePostToVimeo,
+                                                           UIActivityTypePostToWeibo,
+                                                           UIActivityTypePostToTencentWeibo,
+                                                           
                                                            /*
-                                                            The built-in iOS share sheet will pull in `attributedContentText`. 
-                                                            If the official Facebook app is installed, it takes precedent 
-                                                            and does not consume this value.
+                                                            If the official Facebook or Flickr apps are installed, they 
+                                                            take precedent over the system sheets and do *not* consume 
+                                                            `attributedContentText`.
                                                             */
                                                            UIActivityTypePostToFacebook,
-                                                           
-                                                           /*
-                                                            The built-in iOS share sheet will pull in `attributedContentText`.
-                                                            */
-                                                           UIActivityTypePostToTwitter,
-                                                           
-                                                           /*
-                                                            The built-in iOS share sheet will pull in `attributedContentText`.
-                                                            */
-                                                           UIActivityTypePostToVimeo,
-                                                           
-                                                           /*
-                                                            The built-in iOS share sheet will pull in `attributedContentText`. 
-                                                            If the official Flickr app is installed, it takes precedent 
-                                                            and does not consume this value.
-                                                            */
                                                            UIActivityTypePostToFlickr,
                                                            ]];
     


### PR DESCRIPTION
https://github.com/tumblr/XExtensionItem/issues/39

Was able to test Sina Weibo and while I still don’t know how to create a Tencent Weibo account without a Chinese phone number, I’m going to assume it works the same as all the other `PostTo` activities.