### PR TITLE
Exclusively use inferred type identifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,12 +101,12 @@ In addition to a URL, an `XExtensionItemSource` instance can also be initialized
 
 * An `NSString`
 * A `UIImage`
-* `NSData` along with a type identifier
+* `NSData`
 * A placeholder item and a block to lazily provide the actual item (once an activity has been chosen)
 
 #### Advanced attachments
 
-An included `XExtensionItemSource` category provides additional convenience identifiers for lazily supplying URLs, strings, images, or data:
+An included `XExtensionItemSource` category provides additional convenience initializers for lazily supplying URLs, strings, images, or data:
 
 ```objc
 XExtensionItemSource *itemSource = 

--- a/Tests/XExtensionItemTests.m
+++ b/Tests/XExtensionItemTests.m
@@ -65,17 +65,13 @@
 }
 
 - (void)testDataInitializerThrowsIfNil {
-    XCTAssertThrows([[XExtensionItemSource alloc] initWithData:nil typeIdentifier:(NSString *)kUTTypeGIF]);
-}
-
-- (void)testDataInitializerThrowsIfTypeIdentifierIsNil {
-    XCTAssertThrows([[XExtensionItemSource alloc] initWithData:[[NSData alloc] init] typeIdentifier:nil]);
+    XCTAssertThrows([[XExtensionItemSource alloc] initWithData:nil]);
 }
 
 - (void)testDataInitializerProducesExtensionItemWithDataAttachment {
     NSData *data = [NSData dataWithContentsOfFile:[[NSBundle bundleForClass:self.class] pathForResource:@"mountain" ofType:@"png"]];
 
-    XExtensionItemSource *itemSource = [[XExtensionItemSource alloc] initWithData:data typeIdentifier:(NSString *)kUTTypePNG];
+    XExtensionItemSource *itemSource = [[XExtensionItemSource alloc] initWithData:data];
     NSExtensionItem *expected = [[NSExtensionItem alloc] init];
     expected.attachments = @[[[NSItemProvider alloc] initWithItem:data typeIdentifier:(NSString *)kUTTypePNG]];
     
@@ -83,14 +79,14 @@
 }
 
 - (void)testPlaceholderInitializerThrowsIfNil {
-    XCTAssertThrows([[XExtensionItemSource alloc] initWithPlaceholderItem:nil typeIdentifier:nil itemBlock:nil]);
+    XCTAssertThrows([[XExtensionItemSource alloc] initWithPlaceholderItem:nil itemBlock:nil]);
 }
 
 - (void)testPlaceholderInitializerProducesDifferentItemsBasedOnActivityType {
     NSString *defaultString = @"foo";
     NSString *twitterString = @"bar";
     
-    XExtensionItemSource *itemSource = [[XExtensionItemSource alloc] initWithPlaceholderItem:@"placeholder" typeIdentifier:nil itemBlock:^id(NSString *activityType) {
+    XExtensionItemSource *itemSource = [[XExtensionItemSource alloc] initWithPlaceholderItem:@"placeholder" itemBlock:^id(NSString *activityType) {
         if (activityType == UIActivityTypePostToTwitter) {
             return twitterString;
         }
@@ -108,42 +104,6 @@
     expectedNonTwitter.attachments = @[[[NSItemProvider alloc] initWithItem:defaultString typeIdentifier:(NSString *)kUTTypePlainText]];
     
     XExtensionItemAssertEqualItems(expectedNonTwitter, [itemSource activityViewController:nil itemForActivityType:UIActivityTypePostToFacebook]);
-}
-
-- (void)testPlaceholderProvidedTypeIdentifierIsReturnedByActivityItemSourceDelegateMethod {
-    NSString *dataTypeIdentifier = (NSString *)kUTTypeVideo;
-    
-    XExtensionItemSource *source = [[XExtensionItemSource alloc] initWithPlaceholderItem:[[NSData alloc] init]
-                                                                          typeIdentifier:dataTypeIdentifier
-                                                                               itemBlock:nil];
-    
-    XCTAssertEqualObjects(dataTypeIdentifier, [source activityViewController:nil dataTypeIdentifierForActivityType:nil]);
-}
-
-- (void)testPlaceholderTypeIdentifierIsInferredForURL {
-    XExtensionItemSource *source = [[XExtensionItemSource alloc] initWithURL:[NSURL URLWithString:@"http://irace.me"]];
-    
-    XCTAssertEqualObjects((NSString *)kUTTypeURL, [source activityViewController:nil dataTypeIdentifierForActivityType:nil]);
-}
-
-- (void)testPlaceholderTypeIdentifierIsInferredForFileURL {
-    XExtensionItemSource *source = [[XExtensionItemSource alloc] initWithURL:
-                                    [NSURL fileURLWithPath:[[NSBundle bundleForClass:self.class] pathForResource:@"mountain"
-                                                                                                          ofType:@"png"]]];
-    
-    XCTAssertEqualObjects((NSString *)kUTTypePNG, [source activityViewController:nil dataTypeIdentifierForActivityType:nil]);
-}
-
-- (void)testPlaceholderTypeIdentifierIsInferredForString {
-    XExtensionItemSource *source = [[XExtensionItemSource alloc] initWithString:@"Foo"];
-    
-    XCTAssertEqualObjects((NSString *)kUTTypePlainText, [source activityViewController:nil dataTypeIdentifierForActivityType:nil]);
-}
-
-- (void)testPlaceholderTypeIdentifierIsInferredForImage {
-    XExtensionItemSource *source = [[XExtensionItemSource alloc] initWithImage:[[UIImage alloc] init]];
-    
-    XCTAssertEqualObjects((NSString *)kUTTypeImage, [source activityViewController:nil dataTypeIdentifierForActivityType:nil]);
 }
 
 #pragma mark - Output verification

--- a/XExtensionItem.podspec.json
+++ b/XExtensionItem.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "XExtensionItem",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "summary": "Easier sharing between iOS applications and share extensions.",
   "authors": { 
     "Bryan Irace": "bryan@irace.me"
@@ -16,7 +16,7 @@
   "requires_arc": true,
   "source": {
     "git": "https://github.com/tumblr/XExtensionItem.git",
-    "tag": "0.9.1"
+    "tag": "0.9.2"
   },
   "frameworks": [
     "Foundation", 

--- a/XExtensionItem/XExtensionItem.h
+++ b/XExtensionItem/XExtensionItem.h
@@ -197,11 +197,10 @@ typedef UIImage *(^XExtensionItemThumbnailProvidingBlock)(CGSize suggestedSize, 
  Initialize an item source with data.
  
  @param data           (Required) Data to be shared.
- @param typeIdentifier (Required) Type of data.
  
  @return New item source instance.
  */
-- (instancetype)initWithData:(NSData *)data typeIdentifier:(NSString *)typeIdentifier;
+- (instancetype)initWithData:(NSData *)data;
 
 /**
  Initialize a new instance with a placeholder item, whose type will be used by the activity controller to determine
@@ -209,13 +208,11 @@ typedef UIImage *(^XExtensionItemThumbnailProvidingBlock)(CGSize suggestedSize, 
  
  @param placeholderItem (Required) A placeholder item whose type will be used by the activity controller to determine
  which activities and extensions are displayed.
- @param typeIdentifier  (Optional) A uniform type identifier describing the type of content being shared.
  @param itemBlock       (Optional) A block that can provide the item to be shared given the activity type.
  
  @return New item source instance.
  */
 - (instancetype)initWithPlaceholderItem:(id)placeholderItem
-                         typeIdentifier:(NSString *)typeIdentifier
                               itemBlock:(XExtensionItemProvidingBlock)itemBlock NS_DESIGNATED_INITIALIZER;
 
 @end
@@ -230,36 +227,36 @@ typedef UIImage *(^XExtensionItemThumbnailProvidingBlock)(CGSize suggestedSize, 
 
  @param activityType The selected activity type.
 
- @return URL to be provided to the activity.
+ @return Item to be provided to the activity. Can be something other than a URL if you know the selected activity type accepts it.
  */
-typedef NSURL *(^XExtensionItemURLProvidingBlock)(NSString *activityType);
+typedef id (^XExtensionItemURLProvidingBlock)(NSString *activityType);
 
 /**
  A block that can lazily provide a string.
 
  @param activityType The selected activity type.
 
- @return String to be provided to the activity.
+ @return String to be provided to the activity. Can be something other than a string if you know the selected activity type accepts it.
  */
-typedef NSString *(^XExtensionItemStringProvidingBlock)(NSString *activityType);
+typedef id (^XExtensionItemStringProvidingBlock)(NSString *activityType);
 
 /**
  A block that can lazily provide an image.
 
  @param activityType The selected activity type.
 
- @return Image to be provided to the activity.
+ @return Image to be provided to the activity. Can be something other than an image if you know the selected activity type accepts it.
  */
-typedef UIImage *(^XExtensionItemImageProvidingBlock)(NSString *activityType);
+typedef id (^XExtensionItemImageProvidingBlock)(NSString *activityType);
 
 /**
  A block that can lazily provide data of a predetermined type.
 
  @param activityType The selected activity type.
 
- @return Data to be provided to the activity.
+ @return Data to be provided to the activity. Can be something other than data if you know the selected activity type accepts it.
  */
-typedef NSData *(^XExtensionItemDataProvidingBlock)(NSString *activityType);
+typedef id (^XExtensionItemDataProvidingBlock)(NSString *activityType);
 
 /**
  Initialize an item source with a block that can provide a URL.
@@ -274,11 +271,10 @@ typedef NSData *(^XExtensionItemDataProvidingBlock)(NSString *activityType);
  Initialize an item source with a block that can provide a file URL.
  
  @param fileURL        (Required) File URL-providing block.
- @param typeIdentifier (Required) Type identifier for the data that the file consists of.
  
  @return New item source instance.
  */
-- (instancetype)initWithFileURLProvider:(XExtensionItemURLProvidingBlock)fileURL typeIdentifier:(NSString *)typeIdentifier;
+- (instancetype)initWithFileURLProvider:(XExtensionItemURLProvidingBlock)fileURL;
 
 /**
  Initialize an item source with a block that can provide a string.
@@ -302,11 +298,10 @@ typedef NSData *(^XExtensionItemDataProvidingBlock)(NSString *activityType);
  Initialize an item source with a block that can provide data.
  
  @param dataProvider   (Required) Data-providing block.
- @param typeIdentifier (Required) Type identifier for the data
  
  @return New item source instance.
  */
-- (instancetype)initWithDataProvider:(XExtensionItemDataProvidingBlock)dataProvider typeIdentifier:(NSString *)typeIdentifier;
+- (instancetype)initWithDataProvider:(XExtensionItemDataProvidingBlock)dataProvider;
 
 @end
 


### PR DESCRIPTION
Related: https://github.com/tumblr/XExtensionItem/issues/49

We should be able to lazily provide items that _don’t_ match the placeholder’s type, in order to e.g. provide a GIF if the message activity is selected. This requires using our function to calculate the item’s type rather than the type identifier that was provided when the item source was initialized.

The only other place where `self.typeIdentifier` was being used was in the `UIActivityItemSource` protocol’s [`activityViewController:dataTypeIdentifierForActivityType:`](file:///Users/bryan/Library/Developer/Shared/Documentation/DocSets/com.apple.adc.documentation.AppleiOS8.0.iOSLibrary.docset/Contents/Resources/Documents/documentation/UIKit/Reference/UIActivityItemSource_protocol/index.html#//apple_ref/occ/intfm/UIActivityItemSource/activityViewController:dataTypeIdentifierForActivityType:) method, but that seemed to be causing a problem due to the mismatch. I’ve removed it and everything seems to work fine.

Totally possible that I’m overlooking something here – please take a look through and let me know if you think this is necessary for some reason.